### PR TITLE
fixed #4175: Added js-bindings to excludeForder for WebStorm.

### DIFF
--- a/.idea/cocos2d-js.iml
+++ b/.idea/cocos2d-js.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/frameworks/js-bindings" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>
+


### PR DESCRIPTION
fixed #4175: added js-bindings to excludeForder for WebStorm.
