### PR TITLE
Mimic HTML5 cc.p()

### DIFF
--- a/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
+++ b/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
@@ -118,6 +118,10 @@ cc._reuse_color4b = {r:255, g:255, b:255, a:255 };
 //
 cc.p = function( x, y )
 {
+    if (x == undefined)
+        return {x: 0, y: 0};
+    if (y == undefined)
+        return {x: x.x, y: x.y};
     return {x:x, y:y};
 };
 cc._p = function( x, y )


### PR DESCRIPTION
Mimics the behavior of HTML5's cc.p(), returning (0,0) if no args and the given point (cloned) if one argument.
