### PR TITLE
modify the default constructor of ParticleSystem

### DIFF
--- a/frameworks/js-bindings/bindings/script/jsb_create_apis.js
+++ b/frameworks/js-bindings/bindings/script/jsb_create_apis.js
@@ -262,7 +262,7 @@ _p._ctor = function(plistFile){
     if (typeof(plistFile) === "number") {
         var ton = plistFile || 100;
         this.initWithTotalParticles(ton);
-    }else{
+    }else if(typeof(plistFile) === "string"){
         this.initWithFile(plistFile);
     }
 };


### PR DESCRIPTION
it should not init the instance when new cc.ParticleSystem without any parameter.
