### PR TITLE
Update jsb_cocos2d.js

### DIFF
--- a/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
+++ b/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
@@ -272,8 +272,10 @@ cc.SCENE_RADIAL = 0xc001;               //CCTransitionProgress.js
 
 cc.KEY = {
     //android
-    back:8,
-    menu:4199,
+    //back:8,
+    back:6,
+    //menu:4199,
+    menu:15,
     //desktop
     backspace:7,
     tab:8,


### PR DESCRIPTION
cc.KEY 中的 android  back 和 menu 的真机返回值测试结果是：
机型：小米2S
back:6
menu:15
不知道这个值和机型有没有关系，
用之前的 8 和 4199 无法捕获到 返回键和菜单键
