### PR TITLE
no default font Arial on android

### DIFF
--- a/frameworks/js-bindings/bindings/script/jsb_create_apis.js
+++ b/frameworks/js-bindings/bindings/script/jsb_create_apis.js
@@ -762,7 +762,7 @@ cc.LabelTTF.prototype._ctor = function(text, fontName, fontSize, dimensions, hAl
 		this.initWithStringAndTextDefinition(text, fontName);
 	}
 	else {
-		fontName = fontName || "Arial";
+		fontName = fontName || "";
 		fontSize = fontSize || 16;
 		dimensions = dimensions || cc.size(0,0);
 		hAlignment = hAlignment === undefined ? cc.TEXT_ALIGNMENT_LEFT : hAlignment;
@@ -927,7 +927,7 @@ cc.LabelTTF.create = function (text, fontName, fontSize, dimensions, hAlignment,
         label = cc.LabelTTF.createWithFontDefinition(text, fontName);
     }
     else {
-        fontName = fontName || "Arial";
+        fontName = fontName || "";
         fontSize = fontSize || 16;
         dimensions = dimensions || cc.size(0, 0);
         hAlignment = hAlignment == undefined ? cc.TEXT_ALIGNMENT_CENTER : hAlignment;


### PR DESCRIPTION
There is no default font "Arial" on android.
If default font is set to Arial, it always show a warning "No file found at Arial. Possible missing file." on android debugger console.
