### PR TITLE
move jsb scripts to assets/script/

### DIFF
--- a/build/android-build.py
+++ b/build/android-build.py
@@ -124,8 +124,10 @@ def copy_resources(target, app_android_root):
 
     assets_res_dir = assets_dir + "/res";
     assets_scripts_dir = assets_dir + "/src";
+    assets_jsb_dir = assets_dir + "/script";
     os.mkdir(assets_res_dir);
     os.mkdir(assets_scripts_dir);
+    os.mkdir(assets_jsb_dir);
 
     if target in JS_SAMPLES:
         shutil.copy(os.path.join(app_android_root, "../../main.js"), assets_dir)
@@ -139,7 +141,7 @@ def copy_resources(target, app_android_root):
 
         # js project should copy js script
         resources_dir = os.path.join(app_android_root, "../../../../frameworks/js-bindings/bindings/script")
-        copy_files(resources_dir, assets_dir)
+        copy_files(resources_dir, assets_jsb_dir)
 
 def build(targets,ndk_build_param,android_platform,build_mode):
 


### PR DESCRIPTION
[ScriptingCore](https://github.com/cocos2d/cocos2d-js/commit/1af6f1fcfb79e69f8103bbec0947723eb0fd5f00) runs jsb_boot.js from assets/script/jsb_boot.js , but android_build.py moved these files at assets/
