### PR TITLE
Guard for glReleaseShaderCompiler define

### DIFF
--- a/frameworks/js-bindings/bindings/manual/jsb_opengl_manual.h
+++ b/frameworks/js-bindings/bindings/manual/jsb_opengl_manual.h
@@ -38,7 +38,9 @@
 // compatible with iOS
 #define glClearDepthf glClearDepth
 #define glDepthRangef glDepthRange
-#define glReleaseShaderCompiler()
+#ifndef glReleaseShaderCompiler
+	#define glReleaseShaderCompiler()
+#endif
 
 #endif // __MAC_OS_X_VERSION_MAX_ALLOWED
 


### PR DESCRIPTION
The `glReleaseShaderCompiler` macro is also defined in CCGL.h (at least on Mac builds). Adding this guard prevents the macro from being redefined.
