### PR TITLE
setTimeout memory leak fix

### DIFF
--- a/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
+++ b/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
@@ -1616,6 +1616,11 @@ var setTimeout = function (code, delay) {
     var target = new WindowTimeFun(code);
     if (arguments.length > 2)
         target._args = Array.prototype.slice.call(arguments, 2);
+    var original = target.fun;
+    target.fun = function () {
+        original.apply(this, arguments);
+        clearTimeout(target._intervalId);
+    }
     cc.Director.getInstance().getScheduler().scheduleCallbackForTarget(target, target.fun, delay / 1000, 0, 0, false);
     _windowTimeFunHash[target._intervalId] = target;
     return target._intervalId;


### PR DESCRIPTION
Hi
This is a memory leak fix branch.
setTimeout's callback is rooted by scheduler. It should be automatically removed.
I tested using Spidermonkey heap-dump method.
