### PR TITLE
issue  #5791 : use new/delete [] instead of malloc/free for object array

### DIFF
--- a/frameworks/js-bindings/bindings/manual/cocos2d_specifics.cpp
+++ b/frameworks/js-bindings/bindings/manual/cocos2d_specifics.cpp
@@ -2719,7 +2719,7 @@ bool js_BezierActions_create(JSContext *cx, uint32_t argc, jsval *vp) {
         
         T* ret =  T::create(t, config);
         
-        free(arr);
+        delete [] arr;
 
         jsval jsret;
 		do {
@@ -2768,7 +2768,7 @@ bool js_BezierActions_initWithDuration(JSContext *cx, uint32_t argc, jsval *vp)
 
         JSB_PRECONDITION2(ok, cx, false, "js_cocos2dx_Bezier_initWithDuration : Error processing arguments");
         bool ret = cobj->initWithDuration(arg0, arg1);
-        free(arr);
+        delete [] arr;
         jsval jsret = JSVAL_NULL;
         jsret = BOOLEAN_TO_JSVAL(ret);
         JS_SET_RVAL(cx, vp, jsret);
@@ -2805,7 +2805,7 @@ bool js_CardinalSplineActions_create(JSContext *cx, uint32_t argc, jsval *vp) {
         
         T *ret = T::create(dur, points, ten);
         
-        free(arr);
+        delete [] arr;
         
         jsval jsret;
 		do {
@@ -2853,7 +2853,7 @@ bool js_CatmullRomActions_create(JSContext *cx, uint32_t argc, jsval *vp) {
         
         T *ret = T::create(dur, points);
         
-        free(arr);
+        delete [] arr;
         
         jsval jsret;
 		do {
@@ -2902,7 +2902,7 @@ bool js_CatmullRomActions_initWithDuration(JSContext *cx, uint32_t argc, jsval *
         
 		JSB_PRECONDITION2(ok, cx, false, "js_cocos2dx_CatmullRom_initWithDuration : Error processing arguments");
 		bool ret = cobj->initWithDuration(arg0, arg1);
-        free(arr);
+        delete [] arr;
 		jsval jsret = JSVAL_NULL;
 		jsret = BOOLEAN_TO_JSVAL(ret);
 		JS_SET_RVAL(cx, vp, jsret);
@@ -2966,7 +2966,7 @@ bool js_cocos2dx_CardinalSplineTo_initWithDuration(JSContext *cx, uint32_t argc,
 		JSB_PRECONDITION2(ok, cx, false, "js_cocos2dx_CardinalSplineTo_initWithDuration : Error processing arguments");
 		bool ret = cobj->initWithDuration(arg0, arg1, arg2);
         
-        free(arr);
+        delete [] arr;
 		jsval jsret = JSVAL_NULL;
 		jsret = BOOLEAN_TO_JSVAL(ret);
 		JS_SET_RVAL(cx, vp, jsret);

--- a/frameworks/js-bindings/bindings/manual/js_manual_conversions.cpp
+++ b/frameworks/js-bindings/bindings/manual/js_manual_conversions.cpp
@@ -829,8 +829,8 @@ bool jsval_to_ccarray_of_CCPoint(JSContext* cx, jsval v, Point **points, int *nu
     uint32_t len;
     JS_GetArrayLength(cx, jsobj, &len);
     
-    Point *array = (Point*)malloc( sizeof(Point) * len);
-    
+    Point *array = new Point[len];
+
     for( uint32_t i=0; i< len;i++ ) {
         JS::RootedValue valarg(cx);
         JS_GetElement(cx, jsobj, i, &valarg);


### PR DESCRIPTION
To create an array of object, malloc/free will not call the constructor/destructor of the class, and the members of the class maybe not initialized, and we need to call constructor manually.
The correct way is to use `new operator`.
