### PR TITLE
Fix bug: Protobuf parse issue.

### DIFF
--- a/templates/js-template-runtime/frameworks/runtime-src/Classes/runtime/Runtime.cpp
+++ b/templates/js-template-runtime/frameworks/runtime-src/Classes/runtime/Runtime.cpp
@@ -617,7 +617,7 @@ void FileServer::loopReceiveFile()
         recvBuf(fd,_protoBuf,protolength.uint16_type);
         RecvBufStruct recvDataBuf;
         recvDataBuf.fd = fd;
-        recvDataBuf.fileProto.ParseFromString(_protoBuf);
+        recvDataBuf.fileProto.ParseFromArray(_protoBuf, protolength.uint16_type);
         if (1 == recvDataBuf.fileProto.package_seq()){
             _recvErrorFile = "";
         }else{


### PR DESCRIPTION
in `Runtime.cpp` parseFromString operate may result in an incomplete protobuf object, cause `recvDataBuf.fileProto.modified_time()` always return 0.
This pr fixed it.
