### PR TITLE
new cc.ScrollView(size, node) bug fix

### DIFF
--- a/frameworks/js-bindings/bindings/script/jsb_ext_create_apis.js
+++ b/frameworks/js-bindings/bindings/script/jsb_ext_create_apis.js
@@ -178,3 +178,7 @@ cc.EditBox.prototype._ctor = function(size, normal9SpriteBg, press9SpriteBg, dis
             this.setBackgroundSpriteForState(disabled9SpriteBg, cc.CONTROL_STATE_DISABLED);
     }
 };
+
+cc.ScrollView.prototype._ctor = function(size, container) {
+    container == undefined ? this.init() : this.initWithViewSize(size, container);
+};


### PR DESCRIPTION
new cc.ScrollView(size, node) dosen't work on native device. so i fix it.

(https://github.com/cocos2d/cocos2d-html5/issues/2299)
