### PR TITLE
Fix Bug: PrebuiltRuntime ios version can't support portrait orientation.

### DIFF
--- a/templates/js-template-runtime/frameworks/runtime-src/proj.ios_mac/ios/Info.plist
+++ b/templates/js-template-runtime/frameworks/runtime-src/proj.ios_mac/ios/Info.plist
@@ -93,6 +93,7 @@
 	<array>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
I update the latest source code, install the PrebuiltRuntimeJs.ipa on my iphone and debug on iOS Device using Code IDE. But my project can't show normally in portrait orientation, I think this is bug.
