### PR TITLE
fix wrong usage of map

### DIFF
--- a/frameworks/js-bindings/bindings/manual/ScriptingCore.cpp
+++ b/frameworks/js-bindings/bindings/manual/ScriptingCore.cpp
@@ -600,12 +600,12 @@ JSScript* ScriptingCore::getScript(const char *path)
 {
     // a) check jsc file first
     std::string byteCodePath = RemoveFileExt(std::string(path)) + BYTE_CODE_FILE_EXT;
-    if (filename_script[byteCodePath])
+    if (filename_script.find(byteCodePath) != filename_script.end())
         return filename_script[byteCodePath];
     
     // b) no jsc file, check js file
     std::string fullPath = cocos2d::FileUtils::getInstance()->fullPathForFilename(path);
-    if (filename_script[fullPath])
+    if (filename_script.find(fullPath) != filename_script.end())
         return filename_script[fullPath];
     
     return NULL;


### PR DESCRIPTION
if  the path is not in the map, this function will insert 2 pairs into the map.
