### PR TITLE
add cc.MenuItemToggle.prototype.selectedItem to be compatible with h5

### DIFF
--- a/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
+++ b/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
@@ -2847,3 +2847,5 @@ _p.setDisabledSpriteFrame = function(frame) {
         frame = cc.spriteFrameCache.getSpriteFrame(frame.substr(1));
     this._setDisabledSpriteFrame(frame);
 }
+
+cc.MenuItemToggle.prototype.selectedItem = cc.MenuItemToggle.prototype.getSelectedItem;


### PR DESCRIPTION
h5 now has both selectedItem and getSelectedItem
jsb has only getSelectedItem

related changes : https://github.com/cocos2d/cocos2d-html5/pull/2594/files#diff-833fa57df108d09feba03aaf5a323705R1383