### PR TITLE
hide automated test tagglebutton

### DIFF
--- a/samples/js-tests/src/tests-main.js
+++ b/samples/js-tests/src/tests-main.js
@@ -104,7 +104,7 @@ var TestController = cc.LayerGradient.extend({
         var toggleAutoTestItem = new cc.MenuItemToggle(subItem1, subItem2);
         toggleAutoTestItem.setCallback(this.onToggleAutoTest, this);
         toggleAutoTestItem.x = winSize.width - toggleAutoTestItem.width / 2 - 10;
-	    toggleAutoTestItem.y = 20;
+        toggleAutoTestItem.y = 20;
         toggleAutoTestItem.setVisible(false);
         if( autoTestEnabled )
             toggleAutoTestItem.setSelectedIndex(1);

--- a/samples/js-tests/src/tests-main.js
+++ b/samples/js-tests/src/tests-main.js
@@ -105,6 +105,7 @@ var TestController = cc.LayerGradient.extend({
         toggleAutoTestItem.setCallback(this.onToggleAutoTest, this);
         toggleAutoTestItem.x = winSize.width - toggleAutoTestItem.width / 2 - 10;
 	    toggleAutoTestItem.y = 20;
+        toggleAutoTestItem.setVisible(false);
         if( autoTestEnabled )
             toggleAutoTestItem.setSelectedIndex(1);
 


### PR DESCRIPTION
hide automated test tagglebutton, avoid some test case can't not run, when the button opened