### PR TITLE
[JSB] String value with line break character will cause cc.plistParser fail to parse

### DIFF
--- a/frameworks/js-bindings/bindings/manual/cocos2d_specifics.cpp
+++ b/frameworks/js-bindings/bindings/manual/cocos2d_specifics.cpp
@@ -24,6 +24,7 @@
 #include "cocos2d_specifics.hpp"
 #include "cocos2d.h"
 #include <typeinfo>
+#include <regex>
 #include "js_bindings_config.h"
 #include "jsb_cocos2dx_auto.hpp"
 #include "jsb_event_dispatcher_manual.h"
@@ -4212,11 +4213,8 @@ bool js_PlistParser_parse(JSContext *cx, unsigned argc, JS::Value *vp) {
         JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
         
         std::string parsedStr = delegator->parseText(arg0);
-        
-	std::string::size_type pos = 0;
-        while((pos = parsedStr.find("\n", pos)) != -1) {
-            parsedStr.replace(parsedStr.begin() + pos, parsedStr.begin() + pos + 1, "\\n");
-        }
+        std::regex pat("\n");
+        parsedStr = std::regex_replace(parsedStr, pat, "\\n");
         
         jsval strVal = std_string_to_jsval(cx, parsedStr);
         // create a new js obj of the parsed string

--- a/frameworks/js-bindings/bindings/manual/cocos2d_specifics.cpp
+++ b/frameworks/js-bindings/bindings/manual/cocos2d_specifics.cpp
@@ -4212,6 +4212,12 @@ bool js_PlistParser_parse(JSContext *cx, unsigned argc, JS::Value *vp) {
         JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
         
         std::string parsedStr = delegator->parseText(arg0);
+        
+	std::string::size_type pos = 0;
+        while((pos = parsedStr.find("\n", pos)) != -1) {
+            parsedStr.replace(parsedStr.begin() + pos, parsedStr.begin() + pos + 1, "\\n");
+        }
+        
         jsval strVal = std_string_to_jsval(cx, parsedStr);
         // create a new js obj of the parsed string
         JS::RootedValue outVal(cx);

--- a/frameworks/js-bindings/bindings/manual/cocos2d_specifics.cpp
+++ b/frameworks/js-bindings/bindings/manual/cocos2d_specifics.cpp
@@ -24,7 +24,6 @@
 #include "cocos2d_specifics.hpp"
 #include "cocos2d.h"
 #include <typeinfo>
-#include <regex>
 #include "js_bindings_config.h"
 #include "jsb_cocos2dx_auto.hpp"
 #include "jsb_event_dispatcher_manual.h"
@@ -4213,8 +4212,7 @@ bool js_PlistParser_parse(JSContext *cx, unsigned argc, JS::Value *vp) {
         JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
         
         std::string parsedStr = delegator->parseText(arg0);
-        std::regex pat("\n");
-        parsedStr = std::regex_replace(parsedStr, pat, "\\n");
+        std::replace(parsedStr.begin(), parsedStr.end(), '\n', ' ');
         
         jsval strVal = std_string_to_jsval(cx, parsedStr);
         // create a new js obj of the parsed string


### PR DESCRIPTION
I fixed cc.plistParser's parse error.

but i'm not sure that this is best way.

if you have better idea, please give me advice.

have a nice day :)

https://github.com/cocos2d/cocos2d-js/issues/1459

---

test code

```
cc.loader.loadTxt("res/p.plist", function(err, txt){
cc.log(cc.plistParser.parse(txt).g1.frame);
});
```

---

p.plist

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
        <dict>
            <key>g1</key>
            <dict>
                <key>frame</key>
                <string>asda
                sdasadssadsadsad</string>
            </dict>
            <key>g2</key>
            <dict>
                <key>frame</key>
                <string>asdasdasadsadsadsad</string>
            </dict>
        </dict>
</plist>
```