### PR TITLE
Patch XMLHttpRequest.send for ArrayBuffer & ArrayBufferView.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ frameworks/js-bindings/bindings/proj.ios_mac/build/
 
 # Ignore files copied in compilation
 samples/*/project/proj.android/src
+
+*.jsc

--- a/frameworks/js-bindings/bindings/manual/network/XMLHTTPRequest.cpp
+++ b/frameworks/js-bindings/bindings/manual/network/XMLHTTPRequest.cpp
@@ -172,7 +172,15 @@ void MinXmlHttpRequest::_setHttpRequestHeader()
     
 }
 
-
+void MinXmlHttpRequest::_setHttpRequestData(const char *data, size_t len)
+{
+    if (len > 0 &&
+        (_meth.compare("post") == 0 || _meth.compare("POST") == 0 ||
+         _meth.compare("put") == 0 || _meth.compare("PUT") == 0))
+    {
+        _httpRequest->setRequestData(data, len);
+    }
+}
 
 /**
  *  @brief Callback for HTTPRequest. Handles the response and invokes Callback.
@@ -720,20 +728,32 @@ JS_BINDED_FUNC_IMPL(MinXmlHttpRequest, send)
     if (argc == 1)
     {
         JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
-        if (!args.get(0).isString())
+        if (args.get(0).isString())
+        {
+            JSStringWrapper strWrap(args.get(0).toString());
+            data = strWrap.get();
+            _setHttpRequestData(data.c_str(), static_cast<size_t>(data.length()));
+        }
+        else if (args.get(0).isObject())
+        {
+            JSObject obj = args.get(0).toObjectOrNull();
+            if (JS_IsArrayBufferObject(obj))
+            {
+                _setHttpRequestData((const char *)JS_GetArrayBufferData(obj), JS_GetArrayBufferByteLength(obj));
+            }
+            else if (JS_IsArrayBufferViewObject(&obj))
+            {
+                _setHttpRequestData((const char *)JS_GetArrayBufferViewData(obj), JS_GetArrayBufferViewByteLength(obj));
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else
         {
             return false;
         }
-        JSStringWrapper strWrap(args.get(0).toString());
-        data = strWrap.get();
-    }
-
-
-    if (data.length() > 0 &&
-        (_meth.compare("post") == 0 || _meth.compare("POST") == 0 ||
-         _meth.compare("put") == 0 || _meth.compare("PUT") == 0))
-    {
-        _httpRequest->setRequestData(data.c_str(), static_cast<unsigned int>(data.length()));
     }
 
     _setHttpRequestHeader();

--- a/frameworks/js-bindings/bindings/manual/network/XMLHTTPRequest.cpp
+++ b/frameworks/js-bindings/bindings/manual/network/XMLHTTPRequest.cpp
@@ -736,7 +736,7 @@ JS_BINDED_FUNC_IMPL(MinXmlHttpRequest, send)
         }
         else if (args.get(0).isObject())
         {
-            JSObject obj = args.get(0).toObjectOrNull();
+            JSObject *obj = args.get(0).toObjectOrNull();
             if (JS_IsArrayBufferObject(obj))
             {
                 _setHttpRequestData((const char *)JS_GetArrayBufferData(obj), JS_GetArrayBufferByteLength(obj));

--- a/frameworks/js-bindings/bindings/manual/network/XMLHTTPRequest.cpp
+++ b/frameworks/js-bindings/bindings/manual/network/XMLHTTPRequest.cpp
@@ -741,7 +741,7 @@ JS_BINDED_FUNC_IMPL(MinXmlHttpRequest, send)
             {
                 _setHttpRequestData((const char *)JS_GetArrayBufferData(obj), JS_GetArrayBufferByteLength(obj));
             }
-            else if (JS_IsArrayBufferViewObject(&obj))
+            else if (JS_IsArrayBufferViewObject(obj))
             {
                 _setHttpRequestData((const char *)JS_GetArrayBufferViewData(obj), JS_GetArrayBufferViewByteLength(obj));
             }

--- a/frameworks/js-bindings/bindings/manual/network/XMLHTTPRequest.h
+++ b/frameworks/js-bindings/bindings/manual/network/XMLHTTPRequest.h
@@ -92,6 +92,7 @@ private:
     void _gotHeader(std::string header);
     void _setRequestHeader(const char* field, const char* value);
     void _setHttpRequestHeader();
+    void _setHttpRequestData(const char *data, size_t len);
     void _sendRequest(JSContext *cx);
     void _notify(JSObject * callback);
     

--- a/samples/js-tests/project.json
+++ b/samples/js-tests/project.json
@@ -176,6 +176,7 @@
         "src/CocoStudioTest/SceneTest/SceneEditorTest.js",
         "src/CocoStudioTest/CocoStudioTest.js",
         "src/XHRTest/XHRTest.js",
+        "src/XHRTest/XHRArrayBufferTest.js",
 
         "src/Box2dTest/Box2dTest.js",
         "src/ChipmunkTest/ChipmunkTest.js",

--- a/samples/js-tests/src/XHRTest/XHRArrayBufferTest.js
+++ b/samples/js-tests/src/XHRTest/XHRArrayBufferTest.js
@@ -52,10 +52,10 @@ function streamXHREventsToLabel ( xhr, label, textbox, method ) {
 }
 
 
-var XHRTestScene = TestScene.extend({
+var XHRArrayBufferTestScene = TestScene.extend({
     ctor:function () {
         this._super(true);
-        var xhrLayer = new XHRTestLayer();
+        var xhrLayer = new XHRArrayBufferTestLayer();
         this.addChild(xhrLayer);
     },
     runThisTest:function () {
@@ -66,7 +66,7 @@ var XHRTestScene = TestScene.extend({
     }
 });
 
-var XHRTestLayer = cc.Layer.extend({
+var XHRArrayBufferTestLayer = cc.Layer.extend({
     ctor:function () {
         this._super();
     },
@@ -78,93 +78,33 @@ var XHRTestLayer = cc.Layer.extend({
         l.x = winSize.width / 2;
         l.y = winSize.height - 60;
 
-        this.sendGetRequest();
-        this.sendPostPlainText();
-        this.sendPostForms();
+        this.sendPostArrayBuffer();
     },
 
-    sendGetRequest: function() {
-        var statusGetLabel = new cc.LabelTTF("Status:", "Thonburi", 12);
-        this.addChild(statusGetLabel, 1);
+    sendPostArrayBuffer: function() {
+        var statusPostLabel = new cc.LabelTTF("Status:", "Thonburi", 12);
+        this.addChild(statusPostLabel, 1);
 
-        statusGetLabel.x = 10
-        statusGetLabel.y = winSize.height - 100;
-        ensureLeftAligned(statusGetLabel);
-        statusGetLabel.setString("Status: Send Get Request to httpbin.org");
+        statusPostLabel.x = 10;
+        statusPostLabel.y = winSize.height - 100;
+        ensureLeftAligned(statusPostLabel);
+        statusPostLabel.setString("Status: Send Post Request to httpbin.org with ArrayBuffer");
+
 
         var responseLabel = new cc.LabelTTF("", "Thonburi", 16);
         this.addChild(responseLabel, 1);
-
         ensureLeftAligned(responseLabel);
         responseLabel.x = 10;
         responseLabel.y = winSize.height / 2;
-
-        var xhr = cc.loader.getXMLHttpRequest();
-        streamXHREventsToLabel(xhr, statusGetLabel, responseLabel, "GET");
-        // 5 seconds for timeout
-        xhr.timeout = 5000;
-        
-        //set arguments with <URL>?xxx=xxx&yyy=yyy
-        xhr.open("GET", "http://httpbin.org/get?show_env=1", true);
-        xhr.send();
-    },
-
-    sendPostPlainText: function() {
-        var statusPostLabel = new cc.LabelTTF("Status:", "Thonburi", 12);
-        this.addChild(statusPostLabel, 1);
-
-        statusPostLabel.x = winSize.width / 10 * 3;
-        statusPostLabel.y = winSize.height - 100;
-        ensureLeftAligned(statusPostLabel);
-        statusPostLabel.setString("Status: Send Post Request to httpbin.org with plain text");
-
-
-        var responseLabel = new cc.LabelTTF("", "Thonburi", 16);
-        this.addChild(responseLabel, 1);
-        ensureLeftAligned(responseLabel);
-        responseLabel.x = winSize.width / 10 * 3;
-        responseLabel.y = winSize.height / 2;
         
         var xhr = cc.loader.getXMLHttpRequest();
         streamXHREventsToLabel(xhr, statusPostLabel, responseLabel, "POST");
 
         xhr.open("POST", "http://httpbin.org/post");
-        //set Content-type "text/plain;charset=UTF-8" to post plain text
-        xhr.setRequestHeader("Content-Type","text/plain;charset=UTF-8");
-        xhr.send("plain text message");
-    },
-
-    sendPostForms: function() {
-        var statusPostLabel = new cc.LabelTTF("Status:", "Thonburi", 12);
-        this.addChild(statusPostLabel, 1);
-
-        statusPostLabel.x = winSize.width / 10 * 7;
-        statusPostLabel.y = winSize.height - 100;
-        ensureLeftAligned(statusPostLabel);
-        statusPostLabel.setString("Status: Send Post Request to httpbin.org width form data");
-
-        var responseLabel = new cc.LabelTTF("", "Thonburi", 16);
-        this.addChild(responseLabel, 1);
-
-        ensureLeftAligned(responseLabel);
-        responseLabel.x = winSize.width / 10 * 7;
-        responseLabel.y = winSize.height / 2;
-
-        var xhr = cc.loader.getXMLHttpRequest();
-        streamXHREventsToLabel(xhr, statusPostLabel, responseLabel, "POST");
-
-        xhr.open("POST", "http://httpbin.org/post");
-        //set Content-Type "application/x-www-form-urlencoded" to post form data
-        //mulipart/form-data for upload
-        xhr.setRequestHeader("Content-Type","application/x-www-form-urlencoded");
-        /**
-        form : {
-            "a" : "hello",
-            "b" : "world"
-        }
-        **/
-        var args = "a=hello&b=world";
-        xhr.send(args);
+        //set Content-type "text/plain" to post ArrayBuffer or ArrayBufferView
+        xhr.setRequestHeader("Content-Type","text/plain");
+        // Uint8Array is an ArrayBufferView
+        xhr.send(new Uint8Array([1,2,3,4,5]));
     },
 
     scrollViewDidScroll:function (view) {
@@ -173,9 +113,9 @@ var XHRTestLayer = cc.Layer.extend({
     }
 });
 
-var runXHRTest = function () {
+var runXHRArrayBufferTest = function () {
     var pScene = new cc.Scene();
-    var pLayer = new XHRTestLayer();
+    var pLayer = new XHRArrayBufferTestLayer();
     pScene.addChild(pLayer);
     cc.director.runScene(pScene);
 };

--- a/samples/js-tests/src/XHRTest/XHRTest.js
+++ b/samples/js-tests/src/XHRTest/XHRTest.js
@@ -81,6 +81,7 @@ var XHRTestLayer = cc.Layer.extend({
         this.sendGetRequest();
         this.sendPostPlainText();
         this.sendPostForms();
+        this.sendPostArrayBuffer();
     },
 
     sendGetRequest: function() {
@@ -113,7 +114,7 @@ var XHRTestLayer = cc.Layer.extend({
         var statusPostLabel = new cc.LabelTTF("Status:", "Thonburi", 12);
         this.addChild(statusPostLabel, 1);
 
-        statusPostLabel.x = winSize.width / 10 * 3;
+        statusPostLabel.x = winSize.width / 10 * 2.5;
         statusPostLabel.y = winSize.height - 100;
         ensureLeftAligned(statusPostLabel);
         statusPostLabel.setString("Status: Send Post Request to httpbin.org with plain text");
@@ -122,7 +123,7 @@ var XHRTestLayer = cc.Layer.extend({
         var responseLabel = new cc.LabelTTF("", "Thonburi", 16);
         this.addChild(responseLabel, 1);
         ensureLeftAligned(responseLabel);
-        responseLabel.x = winSize.width / 10 * 3;
+        responseLabel.x = winSize.width / 10 * 2.5;
         responseLabel.y = winSize.height / 2;
         
         var xhr = cc.loader.getXMLHttpRequest();
@@ -138,7 +139,7 @@ var XHRTestLayer = cc.Layer.extend({
         var statusPostLabel = new cc.LabelTTF("Status:", "Thonburi", 12);
         this.addChild(statusPostLabel, 1);
 
-        statusPostLabel.x = winSize.width / 10 * 7;
+        statusPostLabel.x = winSize.width / 10 * 5;
         statusPostLabel.y = winSize.height - 100;
         ensureLeftAligned(statusPostLabel);
         statusPostLabel.setString("Status: Send Post Request to httpbin.org width form data");
@@ -147,7 +148,7 @@ var XHRTestLayer = cc.Layer.extend({
         this.addChild(responseLabel, 1);
 
         ensureLeftAligned(responseLabel);
-        responseLabel.x = winSize.width / 10 * 7;
+        responseLabel.x = winSize.width / 10 * 5;
         responseLabel.y = winSize.height / 2;
 
         var xhr = cc.loader.getXMLHttpRequest();
@@ -165,6 +166,32 @@ var XHRTestLayer = cc.Layer.extend({
         **/
         var args = "a=hello&b=world";
         xhr.send(args);
+    },
+
+    sendPostArrayBuffer: function() {
+        var statusPostLabel = new cc.LabelTTF("Status:", "Thonburi", 12);
+        this.addChild(statusPostLabel, 1);
+
+        statusPostLabel.x = winSize.width / 10 * 7.5;
+        statusPostLabel.y = winSize.height - 100;
+        ensureLeftAligned(statusPostLabel);
+        statusPostLabel.setString("Status: Send Post Request to httpbin.org with ArrayBuffer");
+
+
+        var responseLabel = new cc.LabelTTF("", "Thonburi", 16);
+        this.addChild(responseLabel, 1);
+        ensureLeftAligned(responseLabel);
+        responseLabel.x = winSize.width / 10 * 7.5;
+        responseLabel.y = winSize.height / 2;
+        
+        var xhr = cc.loader.getXMLHttpRequest();
+        streamXHREventsToLabel(xhr, statusPostLabel, responseLabel, "POST");
+
+        xhr.open("POST", "http://httpbin.org/post");
+        //set Content-type "text/plain" to post ArrayBuffer or ArrayBufferView
+        xhr.setRequestHeader("Content-Type","text/plain");
+        // Uint8Array is an ArrayBufferView
+        xhr.send(new Uint8Array([1,2,3,4,5]));
     },
 
     scrollViewDidScroll:function (view) {

--- a/samples/js-tests/src/tests-main.js
+++ b/samples/js-tests/src/tests-main.js
@@ -673,6 +673,14 @@ var testNames = [
         testScene:function () {
             return new XHRTestScene();
         }
+    },
+    {
+        title:"XMLHttpRequest send ArrayBuffer",
+        platforms: PLATFORM_ALL,
+        linksrc:"src/XHRTest/XHRArrayBufferTest.js",
+        testScene:function () {
+            return new XHRArrayBufferTestScene();
+        }
     }
 
     //"UserDefaultTest",


### PR DESCRIPTION
XMLHttpRequest 2 can send ArrayBuffer and ArrayBufferView data.
But the previous version of MinXmlHttpRequest is not supported, so we need patch it, it is very useful. For example:
Using this patch, we can use [hprose-html5.js](https://github.com/hprose/hprose-html5) in cocos2d-js directly on every platform.