### PR TITLE
add cocos attr to the script element in templates

### DIFF
--- a/templates/js-template-default/index.html
+++ b/templates/js-template-default/index.html
@@ -23,6 +23,6 @@
 <script src="src/loading.js"></script>
 <canvas id="gameCanvas" width="800" height="450"></canvas>
 <script src="frameworks/cocos2d-html5/CCBoot.js"></script>
-<script src="main.js"></script>
+<script cocos src="main.js"></script>
 </body>
 </html>

--- a/templates/js-template-runtime/index.html
+++ b/templates/js-template-runtime/index.html
@@ -22,6 +22,6 @@
 <body style="padding:0; margin: 0; background: #000;">
 <canvas id="gameCanvas" width="800" height="450"></canvas>
 <script src="frameworks/cocos2d-html5/CCBoot.js"></script>
-<script src="main.js"></script>
+<script cocos src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
To build project.json path, CCBoot.js is looking for a script element
with a cocos attribute. If element is not found, it loads project.json
from the current URL.
cocos attribute should be added in the template, because it is the
default CCBoot.js' behaviour, and usually, project.json is located with
game.min.js file.
https://github.com/cocos2d/cocos2d-html5/blob/develop/CCBoot.js#L2159