### PR TITLE
WINRT added back button support. Check if rendering thread has been cancelled

### DIFF
--- a/frameworks/js-bindings/external/win8.1-universal/OpenGLESPage.xaml.h
+++ b/frameworks/js-bindings/external/win8.1-universal/OpenGLESPage.xaml.h
@@ -40,6 +40,9 @@ namespace cocos2d
         void OnPageLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void OnVisibilityChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::VisibilityChangedEventArgs^ args);
         void OnSwapChainPanelSizeChanged(Platform::Object^ sender, Windows::UI::Xaml::SizeChangedEventArgs^ e);
+#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+        void OnBackButtonPressed(Platform::Object^ sender, Windows::Phone::UI::Input::BackPressedEventArgs^ args);
+#endif
         void GetSwapChainPanelSize(GLsizei* width, GLsizei* height);
         void CreateRenderSurface();
         void DestroyRenderSurface();

--- a/samples/js-moonwarriors/project/proj.win8.1-universal/App.Shared/js-moonwarriors.Shared.vcxitems.filters
+++ b/samples/js-moonwarriors/project/proj.win8.1-universal/App.Shared/js-moonwarriors.Shared.vcxitems.filters
@@ -9,7 +9,7 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\Cocos2dRenderer.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\OpenGLES.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\OpenGLESPage.xaml.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\external\win8.1-universal\OpenGLESPage.xaml.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="$(MSBuildThisFileDirectory)App.xaml" />
@@ -26,7 +26,7 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\Cocos2dRenderer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\OpenGLES.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\OpenGLESPage.xaml.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\external\win8.1-universal\OpenGLESPage.xaml.h" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\external\win8.1-universal\OpenGLESPage.xaml" />

--- a/samples/js-tests/project/proj.win8.1-universal/App.Shared/js-tests.Shared.vcxitems.filters
+++ b/samples/js-tests/project/proj.win8.1-universal/App.Shared/js-tests.Shared.vcxitems.filters
@@ -16,7 +16,7 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\Cocos2dRenderer.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\OpenGLES.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\OpenGLESPage.xaml.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\external\win8.1-universal\OpenGLESPage.xaml.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="$(MSBuildThisFileDirectory)App.xaml" />
@@ -38,7 +38,7 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\Cocos2dRenderer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\OpenGLES.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\cocos2d-x\cocos\platform\win8.1-universal\OpenGLESPage.xaml.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\external\win8.1-universal\OpenGLESPage.xaml.h" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\..\..\frameworks\js-bindings\external\win8.1-universal\OpenGLESPage.xaml" />

--- a/templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.h
+++ b/templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.h
@@ -40,6 +40,9 @@ namespace cocos2d
         void OnPageLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void OnVisibilityChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::VisibilityChangedEventArgs^ args);
         void OnSwapChainPanelSizeChanged(Platform::Object^ sender, Windows::UI::Xaml::SizeChangedEventArgs^ e);
+#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+        void OnBackButtonPressed(Platform::Object^ sender, Windows::Phone::UI::Input::BackPressedEventArgs^ args);
+#endif
         void GetSwapChainPanelSize(GLsizei* width, GLsizei* height);
         void CreateRenderSurface();
         void DestroyRenderSurface();


### PR DESCRIPTION
Minor changes to Windows 8.1 Universal App to support back button and better rendering thread checks for cancelling of thread.