### PR TITLE
fix bug: after the focus change, the layout object can not be used

### DIFF
--- a/frameworks/js-bindings/bindings/manual/ScriptingCore.cpp
+++ b/frameworks/js-bindings/bindings/manual/ScriptingCore.cpp
@@ -1380,9 +1380,6 @@ bool ScriptingCore::handleFocusEvent(void* nativeObj, cocos2d::ui::Widget* widge
 
     bool ret = executeFunctionWithOwner(OBJECT_TO_JSVAL(p->obj), "onFocusChanged", 2, args);
 
-    removeJSObject(_cx, widgetLoseFocus);
-    removeJSObject(_cx, widgetGetFocus);
-
     return ret;
 }
 


### PR DESCRIPTION
fix bug: after the focus change, the layout object can not be used