### PR TITLE
cc.Color() and cc.color() don't replace 0 alpha with 255 no more

### DIFF
--- a/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
+++ b/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
@@ -1094,7 +1094,7 @@ cc.Color = function (r, g, b, a) {
     this.r = r || 0;
     this.g = g || 0;
     this.b = b || 0;
-    this.a = (a == null) ? 255 : a;
+    this.a = (a === undefined) ? 255 : a;
 };
 
 /**
@@ -1124,8 +1124,8 @@ cc.color = function (r, g, b, a) {
     if (typeof r === "string")
         return cc.hexToColor(r);
     if (typeof r === "object")
-        return {r: r.r, g: r.g, b: r.b, a: (r.a == null) ? 255 : r.a};
-    return  {r: r, g: g, b: b, a: (a == null ? 255 : a)};
+        return {r: r.r, g: r.g, b: r.b, a: (r.a === undefined) ? 255 : r.a};
+    return  {r: r, g: g, b: b, a: (a === undefined ? 255 : a)};
 };
 
 /**

--- a/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
+++ b/frameworks/js-bindings/bindings/script/jsb_cocos2d.js
@@ -1094,7 +1094,7 @@ cc.Color = function (r, g, b, a) {
     this.r = r || 0;
     this.g = g || 0;
     this.b = b || 0;
-    this.a = a || 255;
+    this.a = (a == null) ? 255 : a;
 };
 
 /**
@@ -1124,8 +1124,8 @@ cc.color = function (r, g, b, a) {
     if (typeof r === "string")
         return cc.hexToColor(r);
     if (typeof r === "object")
-        return {r: r.r, g: r.g, b: r.b, a: r.a || 255};
-    return  {r: r, g: g, b: b, a: a || 255};
+        return {r: r.r, g: r.g, b: r.b, a: (r.a == null) ? 255 : r.a};
+    return  {r: r, g: g, b: b, a: (a == null ? 255 : a)};
 };
 
 /**


### PR DESCRIPTION
cc.color functions replace 0 alpha with 255:
when you write something like `var myAwesomeColor = cc.color(0, 0, 0, 0);` using JSB you receive your _awesomeColor_ equal to _cc.color(0, 0, 0, 255)_