### PR TITLE
Fixed iOS/JS-Bind callStaticMethod() with bool arg.

### DIFF
--- a/frameworks/js-bindings/bindings/manual/platform/ios/JavaScriptObjCBridge.mm
+++ b/frameworks/js-bindings/bindings/manual/platform/ios/JavaScriptObjCBridge.mm
@@ -111,7 +111,17 @@ bool JavaScriptObjCBridge::CallInfo::execute(JSContext *cx,jsval *argv,unsigned 
         if(m_dic != nil){
             for(int i = 2;i<m_dic.count+2;i++){
                 id obj = [m_dic objectForKey:[NSString stringWithFormat:@"argument%d",i-2] ];
-                [invocation setArgument:&obj atIndex:i];
+                
+                if ([obj isKindOfClass:[NSNumber class]] &&
+                    ((strcmp([obj objCType], "c") == 0 || strcmp([obj objCType], "B") == 0))) //BOOL
+                {
+                    bool b = [obj boolValue];
+                    [invocation setArgument:&b atIndex:i];
+                }
+                else
+                {
+                    [invocation setArgument:&obj atIndex:i];
+                }
             }
         }
         NSUInteger returnLength = [methodSig methodReturnLength];


### PR DESCRIPTION
### Problem
Boolean arguments from **JavaScript** via `jsb.reflection.callStaticMethod()` cannot be received by C++ static methods like:

```objc
+ (void) setAdVisible:(BOOL) isVisible {
   if (isVisible) { // <== This "isVisible" is always NO due to the problem.
    // do something
   } 
}
```
Here is the workaround we are using currently.
```objc
// Workaround
+ (void) setAdVisible:(NSNumber*) isVisible {
   if ([isVisible booleanValue) { //<== Use NSNumber for boolean arguments.
    // do something
   } 
}
```
After this commit **"Fixed iOS/JS-Bind callStaticMethod() with bool arg."**, you can call the function of the upper example.
